### PR TITLE
Botidentifier and message dispatch

### DIFF
--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -57,6 +57,15 @@ class BotPluginBase(StoreMixin):
             self._bot.bot_config.BOT_ADMINS = (self._bot.bot_config.BOT_ADMINS,)
         return self._bot.bot_config
 
+    @property
+    def bot_identifier(self) -> Identifier:
+        """
+        Get bot identifier on current active backend.
+
+        :return Identifier
+        """
+        return self._bot.bot_identifier
+
     def init_storage(self) -> None:
         classname = self.__class__.__name__
         log.debug('Init storage for %s' % classname)

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -516,13 +516,7 @@ class ErrBot(Backend, BotPluginManager):
         """Processes for commands and dispatches the message to all the plugins."""
         if self.process_message(mess):
             # Act only in the backend tells us that this message is OK to broadcast
-            for plugin in self.get_all_active_plugin_objects():
-                # noinspection PyBroadException
-                try:
-                    log.debug('Trigger callback_message on %s' % plugin.__class__.__name__)
-                    plugin.callback_message(mess)
-                except Exception:
-                    log.exception("Crash in a callback_message handler")
+            self._dispatch_to_plugins('callback_message', mess)
 
     def callback_presence(self, pres):
         self._dispatch_to_plugins('callback_presence', pres)


### PR DESCRIPTION
Added ability to get Bot identifier from BotPlugin, because of callback_mention where there`s need to check if Bot is mentioned.

Also dispatch message_callback using new dispatcher.

Related to #564